### PR TITLE
feat: user_carebit_logs のマイグレーション & モデル作成

### DIFF
--- a/app/models/user_carebit_log.rb
+++ b/app/models/user_carebit_log.rb
@@ -1,0 +1,9 @@
+class UserCarebitLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :carebit_action
+
+  enum status: { picked: 0, completed: 1 }
+
+  validates :performed_on, presence: true
+  validates :user_id, uniqueness: { scope: :performed_on, message: "は同じ日に複数のCarebitを登録できません" }
+end

--- a/db/migrate/20250821172621_create_user_carebit_logs.rb
+++ b/db/migrate/20250821172621_create_user_carebit_logs.rb
@@ -1,0 +1,20 @@
+class CreateUserCarebitLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_carebit_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :carebit_action, null: false, foreign_key: true
+      t.date :performed_on, null: false
+      t.integer :status, null: false, default: 0
+      t.text :diary_note
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    # ユーザー × 日付でユニーク
+    add_index :user_carebit_logs, [ :user_id, :performed_on ], unique: true
+
+    # 集計用インデックス
+    add_index :user_carebit_logs, [ :user_id, :status, :performed_on ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_20_090453) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_21_172621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_090453) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_carebit_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "carebit_action_id", null: false
+    t.date "performed_on", null: false
+    t.integer "status", default: 0, null: false
+    t.text "diary_note"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["carebit_action_id"], name: "index_user_carebit_logs_on_carebit_action_id"
+    t.index ["user_id", "performed_on"], name: "index_user_carebit_logs_on_user_id_and_performed_on", unique: true
+    t.index ["user_id", "status", "performed_on"], name: "index_user_carebit_logs_on_user_id_and_status_and_performed_on"
+    t.index ["user_id"], name: "index_user_carebit_logs_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -39,4 +54,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_20_090453) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "user_carebit_logs", "carebit_actions"
+  add_foreign_key "user_carebit_logs", "users"
 end

--- a/test/fixtures/user_carebit_logs.yml
+++ b/test/fixtures/user_carebit_logs.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  carebit_action: one
+  performed_on: 2025-08-22
+  status: 1
+  diary_note: MyText
+  completed_at: 2025-08-22 02:26:21
+
+two:
+  user: two
+  carebit_action: two
+  performed_on: 2025-08-22
+  status: 1
+  diary_note: MyText
+  completed_at: 2025-08-22 02:26:21

--- a/test/models/user_carebit_log_test.rb
+++ b/test/models/user_carebit_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserCarebitLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 📝 概要 / Summary
ユーザーが「今日のCarebit」を選択・完了した記録を保存できる user_carebit_logs テーブルを作成

## 🎯 背景 / Motivation
「今日のCarebit」選択ページやマイページの作成前に、まずは基盤となるログ保存用のテーブルを整えました。

## 🔧 主な変更点 / What changed
- UserCarebitLog モデルを作成
- user_id/carebit_action_idを外部キーとし、statusにはenumを設定
- user_id + performed_on でユニーク制約をし、ユーザーは1日1アクションをDBレベルで制限
- user_id + status + performed_on の複合インデックスで集計の効率化

## ✅ 動作確認手順 / How to test
- rails consoleにてログを作成、statusをcompletedに更新できるか確認

