### PR TITLE
feat: マイページCarebit選択→完了のUI追加

### DIFF
--- a/app/controllers/carebits_controller.rb
+++ b/app/controllers/carebits_controller.rb
@@ -19,7 +19,7 @@ class CarebitsController < ApplicationController
     )
 
     if log.save
-      redirect_to carebit_select_path, notice: "今日のCarebitを選択しました！"
+      redirect_to mypage_path, notice: "今日のCarebitを選択しました！"
     else
       redirect_to carebit_select_path, alert: "同じ日に複数のCarebitは選択できません。"
     end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -7,5 +7,10 @@ class MypagesController < ApplicationController
 
     # カレンダーの基準日を明示的にセット、前月翌月のリンクのため
     @start_date = params.fetch(:start_date, Date.today).to_date
+
+    # 今日のCarebitを完了していたら、励ましメッセージを取得
+    if @today_log&.completed?
+      @encouragement_message = EncouragementMessage.random
+    end
   end
 end

--- a/app/controllers/user_carebit_logs_controller.rb
+++ b/app/controllers/user_carebit_logs_controller.rb
@@ -1,0 +1,14 @@
+class UserCarebitLogsController < ApplicationController
+  before_action :authenticate_user!
+
+  def complete
+    log = current_user.user_carebit_logs.find(params[:id])
+    log.update!(
+      status: :completed,
+      completed_at: Time.current,
+      diary_note: params[:user_carebit_log][:diary_note]
+    )
+
+    redirect_to mypage_path, notice: "今日のCarebitを完了しました！"
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+  def category_image(category)
+    case category
+    when "mental"
+      "mental.png"
+    when "physical"
+      "physical.png"
+    when "lifestyle"
+      "lifestyle.png"
+    else
+      "default.png"
+    end
+  end
 end

--- a/app/models/encouragement_message.rb
+++ b/app/models/encouragement_message.rb
@@ -1,0 +1,5 @@
+class EncouragementMessage < ApplicationRecord
+  def self.random
+    order("RANDOM()").first
+  end
+end

--- a/app/views/carebits/select.html.erb
+++ b/app/views/carebits/select.html.erb
@@ -4,24 +4,30 @@
   <%= form_with url: carebit_choose_path, method: :post, local: true do %>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
       <% [
-        { category: "メンタルケア", action: @mental_action, image: "mental.png" },
-        { category: "体づくり", action: @physical_action, image: "physical.png" },
-        { category: "生活習慣", action: @lifestyle_action, image: "lifestyle.png" }
+        { category: "メンタルケア", action: @mental_action },
+        { category: "体づくり",   action: @physical_action },
+        { category: "生活習慣",   action: @lifestyle_action }
       ].each do |card| %>
         <label class="block cursor-pointer">
+          <!-- ラジオボタン（どのCarebitを選ぶか） -->
           <input type="radio" name="carebit_action_id" value="<%= card[:action].id %>" class="hidden peer">
-          
+
+          <!-- カードデザイン -->
           <div class="bg-white shadow rounded-xl p-6 flex flex-col items-center transition transform hover:scale-105 peer-checked:ring-4 peer-checked:ring-logo">
+            <!-- カテゴリ名 -->
             <h2 class="text-lg font-semibold text-logo mb-2"><%= card[:category] %></h2>
-            
-            <%= image_tag card[:image], class: "w-16 h-16 mb-3" %>
-            
+
+            <!-- カテゴリに応じた画像 -->
+            <%= image_tag category_image(card[:action].category), class: "w-16 h-16 mb-3" %>
+
+            <!-- アクション名 -->
             <p class="text-xl font-bold text-main text-center"><%= card[:action].title %></p>
           </div>
         </label>
       <% end %>
     </div>
 
+    <!-- ボタン群 -->
     <div class="flex justify-center gap-6">
       <%= link_to "チェンジ", carebit_select_path, class: "btn text-lg px-6 py-3" %>
       <%= submit_tag "これにする！", class: "btn text-lg px-6 py-3" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,15 +6,15 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
 
     <%# ページ個別の <head> 追記が必要なとき用 %>
     <%= yield :head %>
 
     <%# PWA/アイコン（元のレイアウトから維持） %>
     <link rel="manifest" href="/manifest.json">
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
+    <%= favicon_link_tag "logo.png", rel: "icon", type: "image/png" %>
+    <%= favicon_link_tag "logo.png", rel: "apple-touch-icon", type: "image/png" %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 

--- a/app/views/mypages/_diary_modal.html.erb
+++ b/app/views/mypages/_diary_modal.html.erb
@@ -1,0 +1,23 @@
+<div id="complete-modal" class="fixed inset-0 flex items-center justify-center hidden z-50">
+  <div class="bg-green-50 rounded-lg shadow-lg p-8 w-[32rem] border-4 border-green-600">
+    <h3 class="text-xl font-bold mb-6 text-center text-green-800">ひとこと日記を追加</h3>
+
+    <%= form_with model: @today_log, url: complete_user_carebit_log_path(@today_log), method: :patch, local: true do |f| %>
+      <%= f.text_area :diary_note,
+            rows: 5,
+            placeholder: "今日の気持ちや一言を残せます",
+            class: "w-full border rounded p-3 mb-6 text-lg bg-white" %>
+
+      <div class="flex justify-end gap-3">
+        <%= button_to "日記を残さず完了する",
+              complete_user_carebit_log_path(@today_log),
+              method: :patch,
+              params: { diary_note: "" },
+              class: "px-5 py-3 bg-gray-300 rounded hover:bg-gray-400 cursor-pointer transition font-semibold" %>
+
+        <%= f.submit "完了する",
+              class: "px-5 py-3 bg-green-600 text-white rounded hover:bg-green-700 cursor-pointer transition font-semibold" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -9,13 +9,12 @@
       <!-- カレンダー下に月移動リンクを配置 -->
       <div class="flex justify-between mt-4">
         <%= link_to "◀ 前月",
-            url_for(params.permit(:start_date).to_h.merge(start_date: @start_date - 1.month)),
-            class: "px-4 py-2 bg-gray-200 rounded hover:bg-gray-300" %>
+              url_for(params.permit(:start_date).to_h.merge(start_date: @start_date - 1.month)),
+              class: "px-4 py-2 bg-gray-200 rounded hover:bg-gray-300" %>
 
         <%= link_to "翌月 ▶",
-            url_for(params.permit(:start_date).to_h.merge(start_date: @start_date + 1.month)),
-            class: "px-4 py-2 bg-gray-200 rounded hover:bg-gray-300" %>
-
+              url_for(params.permit(:start_date).to_h.merge(start_date: @start_date + 1.month)),
+              class: "px-4 py-2 bg-gray-200 rounded hover:bg-gray-300" %>
       </div>
     </div>
   </div>
@@ -35,11 +34,50 @@
           <p class="font-semibold text-gray-700">まだCarebitが選択されていません</p>
           <%= link_to "👉 今日のCarebitを選ぶ", carebit_select_path, 
                 class: "w-full py-3 text-lg bg-green-600 text-white rounded-lg shadow hover:bg-green-700 transition" %>
-          <%= link_to "📊 実績を確認する", "#", 
-                class: "w-full py-3 text-lg bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition" %>
+        </div>
+
+      <% elsif @today_log.picked? %>
+        <!-- 選択済み（未完了） -->
+        <div class="bg-white rounded-lg shadow p-6 flex flex-col items-center text-center">
+          <%= image_tag category_image(@today_log.carebit_action.category), class: "w-16 h-16 mb-4" %>
+          <p class="text-lg font-bold text-gray-800 mb-4"><%= @today_log.carebit_action.title %></p>
+          
+          <!-- 完了ボタン -->
+          <button type="button"
+                  class="btn w-full py-3 text-lg"
+                  onclick="document.getElementById('complete-modal').classList.remove('hidden')">
+            完了する
+          </button>
+
+          <!-- モーダル -->
+          <%= render "mypages/diary_modal" if @today_log&.picked? %>
+        </div>
+
+      <% elsif @today_log.completed? %>
+        <!-- 完了済み -->
+        <div class="bg-white rounded-lg shadow p-6 flex flex-col items-center text-center border-4 border-orange-400">
+          <%= image_tag category_image(@today_log.carebit_action.category), class: "w-16 h-16 mb-4" %>
+          
+          <!-- アクション名 -->
+          <p class="text-lg font-bold text-gray-800 mb-2"><%= @today_log.carebit_action.title %></p>
+
+          <!-- 完了メッセージ -->
+          <p class="text-orange-600 font-semibold mt-2">
+            <%= @encouragement_message.text %>
+          </p>
+
+          <% if @today_log.diary_note.present? %>
+            <div class="mt-4 p-3 w-full bg-orange-50 rounded text-gray-700 text-sm border border-orange-200">
+              <%= @today_log.diary_note %>
+            </div>
+          <% end %>
         </div>
       <% end %>
 
+      <!-- 共通：実績ページへのリンク -->
+      <%= link_to "実績を確認する", "#", 
+            class: "w-full py-3 text-lg text-center bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition" %>
+      
       <!-- 下部にちょっとした励ましメッセージ -->
       <div class="mt-6 text-sm text-gray-600 text-center italic">
         「小さな一歩が、大きな習慣に」

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,13 @@ Rails.application.routes.draw do
   # マイページ
   get "mypage", to: "mypages#show"
 
+  # Carebitログ完了アクション
+  resources :user_carebit_logs, only: [] do
+    member do
+      patch :complete
+    end
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250823133723_create_encouragement_messages.rb
+++ b/db/migrate/20250823133723_create_encouragement_messages.rb
@@ -1,0 +1,9 @@
+class CreateEncouragementMessages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :encouragement_messages do |t|
+      t.string :text
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_21_172621) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_23_133723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "carebit_actions", force: :cascade do |t|
     t.integer "category"
     t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "encouragement_messages", force: :cascade do |t|
+    t.string "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 # db/seeds.rb
 
+# --- Carebitアクションの投入 ---
 carebit_actions = {
   mental: [
     "深呼吸を3回する",
@@ -163,4 +164,20 @@ carebit_actions.each do |category, titles|
   titles.each do |title|
     CarebitAction.find_or_create_by!(category: CarebitAction.categories[category], title: title)
   end
+end
+
+# --- 完了後メッセージの投入 ---
+encouragement_messages = [
+  "✨ 今日もおつかれさま！",
+  "☀️ 積み重ねが未来を変えるよ",
+  "💪 継続できて素晴らしい！",
+  "🌸 自分をちゃんと大事にできてるね",
+  "🎉 Carebit達成！よくがんばった！",
+  "🍀 自分を褒めてあげよう",
+  "😌 心と体、ちゃんとケアできたね",
+  "🌈 その調子！"
+]
+
+encouragement_messages.each do |msg|
+  EncouragementMessage.find_or_create_by!(text: msg)
 end

--- a/test/fixtures/encouragement_messages.yml
+++ b/test/fixtures/encouragement_messages.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  text: MyString
+
+two:
+  text: MyString

--- a/test/models/encouragement_message_test.rb
+++ b/test/models/encouragement_message_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EncouragementMessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 📝 概要 / Summary
- マイページにて「今日のCarebit」選択後・完了後のフローを実装
- 完了時にひとこと日記を入力できるモーダルを追加
- 完了後のカードに登録したひとこと日記を表示
-  完了後のカードに励ましメッセージをランダム表示

## 🔧 主な変更点 / What changed
- `UserCarebitLogsController`
  - `complete` アクションに `diary_note` 保存処理を追加
- `app/views/mypages/show.html.erb`
  - Carebit 未選択 / 選択中 / 完了済み で UI を切り替え
- `app/views/mypages/_diary_modal.html.erb`
  - 完了時にモーダルで日記入力できるフォームを追加
- encourragement_messageテーブルを作成

## ✅ 動作確認手順 / How to test
1. マイページで「今日のCarebit」を選択 → カードに表示される
2. 「完了する」ボタンを押すとモーダルが表示される
3. 日記を入力して保存 → `user_carebit_logs.diary_note` に保存される
4. 完了後カードに日記が表示され、オレンジ枠付きの達成UIになる
5. 「日記を残さず完了する」でも完了可能
6. 完了後カードにランダムな励ましメッセージが表示される 